### PR TITLE
Fix issue where users were not able to revert tasks

### DIFF
--- a/src/components/AuditLog.tsx
+++ b/src/components/AuditLog.tsx
@@ -45,7 +45,11 @@ export const AuditLog = ({ entries, currentUserId, initialHasMore }: Props) => {
 
 	const undo = (id: string) => {
 		startTransition(async () => {
-			const res = await fetch(`/api/logs/${id}`, { method: "PATCH" });
+			const res = await fetch(`/api/logs/${id}`, {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ action: "revert" }),
+			});
 
 			if (!res.ok) {
 				const body = await res.json().catch(() => ({}));


### PR DESCRIPTION
- Send { action: "revert" } with undo PATCH requests so /api/logs/[id] accepts the payload.
- Prevents “Invalid payload” errors when undoing a log entry.