### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     tags: ["v*.*.*"]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jonocairns/tskr/security/code-scanning/1](https://github.com/jonocairns/tskr/security/code-scanning/1)

In general, the fix is to explicitly define minimal GITHUB_TOKEN permissions for this workflow or job. Since the job only needs to read repository contents (for `actions/checkout` and to run code), we can safely set `contents: read`. No write permissions (e.g., for `pull-requests`, `issues`, or `contents: write`) are required by the shown steps.

The best minimal fix without changing existing functionality is to add a `permissions:` block at the workflow root (top level) so it applies to all jobs in this file. Insert it between the `on:` block and the `jobs:` block. Concretely, in `.github/workflows/ci.yml`, add:

```yml
permissions:
  contents: read
```

after line 7 (after the `pull_request:` trigger). This does not change any steps or environment variables and only constrains the implicit GITHUB_TOKEN to read-only access to repository contents, which is sufficient for this CI workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
